### PR TITLE
Fix memory leak 

### DIFF
--- a/Sources/VLCUI/VLCVideoPlayer/Proxy.swift
+++ b/Sources/VLCUI/VLCVideoPlayer/Proxy.swift
@@ -18,8 +18,8 @@ public extension VLCVideoPlayer {
 
     class Proxy: ObservableObject {
 
-        var mediaPlayer: VLCMediaPlayer?
-        var videoPlayerView: UIVLCVideoPlayerView?
+        waek var mediaPlayer: VLCMediaPlayer?
+        weak var videoPlayerView: UIVLCVideoPlayerView?
 
         public init() {
             self.mediaPlayer = nil

--- a/Sources/VLCUI/VLCVideoPlayer/Proxy.swift
+++ b/Sources/VLCUI/VLCVideoPlayer/Proxy.swift
@@ -18,7 +18,7 @@ public extension VLCVideoPlayer {
 
     class Proxy: ObservableObject {
 
-        waek var mediaPlayer: VLCMediaPlayer?
+        weak var mediaPlayer: VLCMediaPlayer?
         weak var videoPlayerView: UIVLCVideoPlayerView?
 
         public init() {


### PR DESCRIPTION
The proxy object shouldn't hold a strong reference to VLCMediaPlayer and UIVLCVideoPlayerView