### PR TITLE
Add skipInitialTimeSet to prevent seeking on live streams

### DIFF
--- a/Sources/VLCUI/UIVLCVideoPlayerView.swift
+++ b/Sources/VLCUI/UIVLCVideoPlayerView.swift
@@ -233,7 +233,9 @@ extension UIVLCVideoPlayerView: VLCMediaPlayerDelegate {
 
     private func setConfigurationValues(with player: VLCMediaPlayer, from configuration: VLCVideoPlayer.Configuration) {
 
-        player.time = VLCTime(int: configuration.startTime.asTicks.asInt32)
+        if !configuration.skipInitialTimeSet {
+            player.time = VLCTime(int: configuration.startTime.asTicks.asInt32)
+        }
 
         let defaultPlayerSpeed = player.rate(from: configuration.rate)
         player.fastForward(atRate: defaultPlayerSpeed)

--- a/Sources/VLCUI/VLCVideoPlayer/Configuration.swift
+++ b/Sources/VLCUI/VLCVideoPlayer/Configuration.swift
@@ -23,6 +23,14 @@ public extension VLCVideoPlayer {
         public var subtitleColor: ValueSelector<_PlatformColor> = .auto
         public var playbackChildren: [PlaybackChild] = []
         public var options: [String: Any] = [:]
+        /// When `true`, the initial `player.time` assignment in
+        /// `setConfigurationValues` is skipped.
+        ///
+        /// Use this for live streams where an explicit seek — even to the
+        /// current position — causes VLC to flush its buffers and re-acquire
+        /// the stream, resulting in long rebuffering delays or loss of the
+        /// live-edge position.
+        public var skipInitialTimeSet: Bool = false
 
         public init(url: URL) {
             self.url = url


### PR DESCRIPTION
## Summary

- Adds `skipInitialTimeSet: Bool` property to `Configuration` (default `false`, no breaking changes)
- When `true`, `setConfigurationValues` skips the `player.time =` assignment, preventing VLC from seeking away from the live edge on live HLS streams
- All other configuration values (rate, subtitles, audio, aspect fill) still apply normally

Fixes #26

## Problem

`setConfigurationValues` unconditionally sets `player.time = startTime` (default `.ticks(0)`) the first time playback advances. For live HLS streams with timeshift buffers, this causes:

1. VLC connects at the live edge correctly
2. `setConfigurationValues` seeks to position 0 (start of timeshift buffer)
3. VLC flushes buffers and re-acquires segments, causing 3+ minute rebuffer
4. Playback resumes hours behind real-time

Even setting `startTime` to the current position causes VLC to flush buffers and rebuffer, because any `player.time = X` call triggers a seek in VLCKit.

## Test plan

- [ ] Verify live HLS stream with `skipInitialTimeSet = true` starts at live edge without rebuffering
- [ ] Verify VOD playback with `skipInitialTimeSet = false` (default) behaves unchanged
- [ ] Verify VOD playback with explicit `startTime` still seeks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)